### PR TITLE
Send release action notification only for archived items

### DIFF
--- a/dspace-ldn/src/main/java/org/dspace/app/ldn/consumer/LDNConsumer.java
+++ b/dspace-ldn/src/main/java/org/dspace/app/ldn/consumer/LDNConsumer.java
@@ -25,13 +25,10 @@ import org.dspace.content.Item;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.ItemService;
-import org.dspace.content.service.WorkspaceItemService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.event.Consumer;
 import org.dspace.event.Event;
-import org.dspace.workflow.WorkflowItemService;
-import org.dspace.workflow.factory.WorkflowServiceFactory;
 
 /**
  * Consumer listening for item deposit or update to announce release
@@ -42,10 +39,6 @@ public class LDNConsumer implements Consumer {
     private final static Logger log = LogManager.getLogger(LDNConsumer.class);
 
     private static Set<Item> itemsToRelease;
-
-    private WorkflowItemService<?> workflowItemService;
-
-    private WorkspaceItemService workspaceItemService;
 
     private ItemService itemService;
 
@@ -58,8 +51,6 @@ public class LDNConsumer implements Consumer {
      */
     @Override
     public void initialize() throws Exception {
-        workflowItemService = WorkflowServiceFactory.getInstance().getWorkflowItemService();
-        workspaceItemService = ContentServiceFactory.getInstance().getWorkspaceItemService();
         itemService = ContentServiceFactory.getInstance().getItemService();
         ldnBusinessDelegate = LDNBusinessDelegateFactory.getInstance().getLDNBusinessDelegate();
     }
@@ -86,7 +77,7 @@ public class LDNConsumer implements Consumer {
 
         if (subjectType == Constants.ITEM) {
 
-            if (eventType == Event.INSTALL ||
+            if (eventType == Event.MODIFY ||
                     eventType == Event.MODIFY_METADATA) {
 
                 Item item = (Item) event.getSubject(context);
@@ -96,44 +87,42 @@ public class LDNConsumer implements Consumer {
                     return;
                 }
 
-                if (workspaceItemService.findByItem(context, item) != null ||
-                        workflowItemService.findByItem(context, item) != null) {
-                    log.info("Ignoring item {} as a corresponding workspace or workflow item exists", item.getID());
-                    return;
-                }
+                if (item.isArchived() || ("ARCHIVED: " + true).equals(event.getDetail())) {
+                    if (eventType == Event.MODIFY_METADATA) {
+                        List<MetadataValue> releaseMetadata = itemService.getMetadata(item, SCHEMA, ELEMENT, RELEASE, ANY);
 
-                if (eventType == Event.MODIFY_METADATA) {
-                    List<MetadataValue> releaseMetadata = itemService.getMetadata(item, SCHEMA, ELEMENT, RELEASE, ANY);
-
-                    if (!releaseMetadata.isEmpty()) {
-                        itemsToRelease.remove(item);
-                        log.info("Skipping item {} as it has been notified of release", item.getID());
-                        for (MetadataValue metadatum : releaseMetadata) {
-                            log.info("\t {}.{}.{} {} {}", SCHEMA, ELEMENT, RELEASE, ANY, metadatum.getValue());
+                        if (!releaseMetadata.isEmpty()) {
+                            itemsToRelease.remove(item);
+                            log.info("Skipping item {} as it has been notified of release", item.getID());
+                            for (MetadataValue metadatum : releaseMetadata) {
+                                log.info("\t {}.{}.{} {} {}", SCHEMA, ELEMENT, RELEASE, ANY, metadatum.getValue());
+                            }
+                            return;
                         }
+
+                    }
+
+                    List<MetadataValue> researchMetadata = itemService.getMetadata(item, "dc", "data", "uri", ANY);
+
+                    if (researchMetadata.isEmpty()) {
+                        log.info("Skipping item {} as it has no identifier to notify", item.getID());
                         return;
                     }
 
-                }
+                    for (MetadataValue metadatum : researchMetadata) {
+                        if (!item.getMetadata().contains(metadatum)) {
+                            item.getMetadata().add(metadatum);
+                        }
+                    }
 
-                List<MetadataValue> researchMetadata = itemService.getMetadata(item, "dc", "data", "uri", ANY);
-
-                if (researchMetadata.isEmpty()) {
-                    log.info("Skipping item {} as it has no identifier to notify", item.getID());
+                    if (!itemsToRelease.add(item)) {
+                        itemsToRelease.remove(item);
+                        itemsToRelease.add(item);
+                    }
+                } else {
+                    log.info("Ignoring item {} as it is not archived or being archived", item.getID());
                     return;
                 }
-
-                for (MetadataValue metadatum : researchMetadata) {
-                    if (!item.getMetadata().contains(metadatum)) {
-                        item.getMetadata().add(metadatum);
-                    }
-                }
-
-                if (!itemsToRelease.add(item)) {
-                    itemsToRelease.remove(item);
-                    itemsToRelease.add(item);
-                }
-
             }
         } else {
             log.warn("Skipping event {} as not an expected type for this consumer", event.toString());


### PR DESCRIPTION
LDN Consumer only send release action notification when item is archived with research data provided or when an archived item is updated with research data provided.

* Resolves #29 

- Check if item is archived or the event is to archive.
