### PR TITLE
Add allowed external resolver URLs

### DIFF
--- a/dspace-ldn/src/main/java/org/dspace/app/ldn/processor/LDNMetadataProcessor.java
+++ b/dspace-ldn/src/main/java/org/dspace/app/ldn/processor/LDNMetadataProcessor.java
@@ -79,6 +79,8 @@ public class LDNMetadataProcessor implements LDNProcessor {
 
     private List<LDNMetadataChange> changes = new ArrayList<>();
 
+    private List<String> allowedExternalResolverUrls = new ArrayList<>();
+
     private String dspaceUIUrl;
 
     /**
@@ -94,6 +96,13 @@ public class LDNMetadataProcessor implements LDNProcessor {
 
     @PostConstruct
     public void init() {
+        String allowedExternalResolverUrls = configurationService.getProperty("ldn.notify.allowed-external-resolver-urls");
+        if (allowedExternalResolverUrls != null) {
+            for (String allowedExternalResolverUrl : allowedExternalResolverUrls.split(",")) {
+                this.allowedExternalResolverUrls.add(allowedExternalResolverUrl.trim());
+            }
+        }
+
         this.dspaceUIUrl = configurationService.getProperty("dspace.ui.url");
     }
 
@@ -343,24 +352,36 @@ public class LDNMetadataProcessor implements LDNProcessor {
      */
     private String resolveContext(Notification notification) {
         String url = notification.getContext().getId();
-        if (!url.startsWith(this.dspaceUIUrl)) {
-            log.info("Attempting to resolve external context id {}", url);
-            try {
-                HttpHeaders headers = this.restTemplate.headForHeaders(url);
-                if (headers.containsKey(LOCATION_HEADER_KEY)) {
-                    return headers.getFirst(LOCATION_HEADER_KEY);
-                } else {
-                    log.error("External context id {} HEAD response did not contain Location header", url);
-                    throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
-                            format("Invalid context id %s", url));
-                }
-            } catch (RestClientException e) {
-                log.error(format("Failed to resolve context id %s.", url), e);
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
-                        format("Failed to resolve context id %s. %s", url, e.getMessage()));
+        if (url.startsWith(this.dspaceUIUrl)) {
+            return url;
+        }
+        boolean allowExternalContextId = false;
+        for (String allowedExternalResolverUrl : this.allowedExternalResolverUrls) {
+            if (url.startsWith(allowedExternalResolverUrl)) {
+                allowExternalContextId = true;
+                break;
             }
         }
-        return url;
+        if (!allowExternalContextId) {
+            String message = format("Context id %s not allowed for external dereference.", url);
+            log.error(message);
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, message);
+        }
+        log.info("Attempting to resolve external context id {}", url);
+        try {
+            HttpHeaders headers = this.restTemplate.headForHeaders(url);
+            if (headers.containsKey(LOCATION_HEADER_KEY)) {
+                return headers.getFirst(LOCATION_HEADER_KEY);
+            } else {
+                log.error("External context id {} HEAD response did not contain Location header", url);
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        format("Invalid context id %s", url));
+            }
+        } catch (RestClientException e) {
+            log.error(format("Failed to resolve context id %s.", url), e);
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    format("Failed to resolve context id %s. %s", url, e.getMessage()));
+        }
     }
 
     /**

--- a/dspace-ldn/src/main/java/org/dspace/app/ldn/processor/LDNMetadataProcessor.java
+++ b/dspace-ldn/src/main/java/org/dspace/app/ldn/processor/LDNMetadataProcessor.java
@@ -96,9 +96,9 @@ public class LDNMetadataProcessor implements LDNProcessor {
 
     @PostConstruct
     public void init() {
-        String allowedExternalResolverUrls = configurationService.getProperty("ldn.notify.allowed-external-resolver-urls");
-        if (allowedExternalResolverUrls != null) {
-            for (String allowedExternalResolverUrl : allowedExternalResolverUrls.split(",")) {
+        String resolverUrls = configurationService.getProperty("ldn.notify.allowed-external-resolver-urls");
+        if (resolverUrls != null) {
+            for (String allowedExternalResolverUrl : resolverUrls.split(",")) {
                 this.allowedExternalResolverUrls.add(allowedExternalResolverUrl.trim());
             }
         }

--- a/dspace/config/modules/ldn.cfg
+++ b/dspace/config/modules/ldn.cfg
@@ -5,6 +5,7 @@ ldn.enabled = true
 
 ldn.notify.local-inbox-endpoint = ${dspace.server.url}/ldn/inbox
 
+ldn.notify.allowed-external-resolver-urls = https://nrsadmin-api-dev.lib.harvard.edu
 
 # List the external services IDs for review/endorsement
 # These IDs needs to be configured in the input-form.xml as well
@@ -15,16 +16,16 @@ ldn.notify.local-inbox-endpoint = ${dspace.server.url}/ldn/inbox
 # Each IDs must match with the ID returned by the external service 
 # in the JSON-LD Actor field
 
-service.service-id.ldn = dev-hdc3b.lib.harvard.edu/api/inbox
+service.service-id.ldn = hdc-dash-api-dev.lib.harvard.edu/api/inbox
 
-service.dev-hdc3b.lib.harvard.edu/api/inbox.url = http://dev-hdc3b.lib.harvard.edu
+service.hdc-dash-api-dev.lib.harvard.edu/api/inbox.url = https://hdc-dash-api-dev.lib.harvard.edu
 
-service.dev-hdc3b.lib.harvard.edu/api/inbox.inbox.url = http://dev-hdc3b.lib.harvard.edu/api/inbox
+service.hdc-dash-api-dev.lib.harvard.edu/api/inbox.inbox.url = https://hdc-dash-api-dev.lib.harvard.edu/api/inbox
 
-service.dev-hdc3b.lib.harvard.edu/api/inbox.resolver.url = http://dev-hdc3b.lib.harvard.edu/dataset.xhtml?persistentId=
+service.hdc-dash-api-dev.lib.harvard.edu/api/inbox.resolver.url = https://hdc-dash-api-dev.lib.harvard.edu/dataset.xhtml?persistentId=
 
-service.dev-hdc3b.lib.harvard.edu/api/inbox.name = Dataverse Sandbox
+service.hdc-dash-api-dev.lib.harvard.edu/api/inbox.name = Dataverse Sandbox
 
-service.dev-hdc3b.lib.harvard.edu/api/inbox.key = 8df0c72a-56b5-44ef-b1c0-b4dbcbcffcd4
+service.hdc-dash-api-dev.lib.harvard.edu/api/inbox.key = 8df0c72a-56b5-44ef-b1c0-b4dbcbcffcd4
 
-service.dev-hdc3b.lib.harvard.edu/api/inbox.key.header = X-Dataverse-key
+service.hdc-dash-api-dev.lib.harvard.edu/api/inbox.key.header = X-Dataverse-key


### PR DESCRIPTION
Resolves #41 

- add allowed external resolver URLs config `ldn.notify.allowed-external-resolver-urls`
- validate external context ids against allowed external resolver URLs
